### PR TITLE
New mag types

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,9 +4,17 @@ Changelog for Stingray Controller
 0.4.6 (unreleased)
 ------------------
 
+Added:
+^^^^^^
+- ML barcodes may end in any digit other than ``1``, ``3``, or ``4``
+
 Changed:
 ^^^^^^^^
 - Installer now prompts whether to install for only the current user or for all users
+
+Fixed:
+^^^^^^
+- Error and warning modals are no longer hidden when clicking outside of them
 
 
 0.4.5 (2024-01-28)

--- a/ui/components/status/BarcodeViewer.vue
+++ b/ui/components/status/BarcodeViewer.vue
@@ -29,10 +29,24 @@
         </div>
       </span>
     </div>
-    <b-modal id="edit-plate-barcode-modal" size="sm" hide-footer hide-header hide-header-close>
+    <b-modal
+      id="edit-plate-barcode-modal"
+      size="sm"
+      hide-footer
+      hide-header
+      hide-header-close
+      :no-close-on-backdrop="true"
+    >
       <StatusWarningWidget :modalLabels="barcodeManualLabels" @handle-confirmation="handleManualModeChoice" />
     </b-modal>
-    <b-modal id="barcode-warning" size="sm" hide-footer hide-header hide-header-close>
+    <b-modal
+      id="barcode-warning"
+      size="sm"
+      hide-footer
+      hide-header
+      hide-header-close
+      :no-close-on-backdrop="true"
+    >
       <StatusWarningWidget :modalLabels="barcodeWarningLabels" @handle-confirmation="closeWarningModal" />
     </b-modal>
   </div>

--- a/ui/components/status/StatusBar.vue
+++ b/ui/components/status/StatusBar.vue
@@ -2,7 +2,15 @@
   <div class="div__status-bar">
     <span class="span__status-bar-text">Status: {{ alertTxt }}</span>
     <span>
-      <b-modal id="error-catch" size="sm" hide-footer hide-header hide-header-close :static="true">
+      <b-modal
+        id="error-catch"
+        size="sm"
+        hide-footer
+        hide-header
+        hide-header-close
+        :static="true"
+        :no-close-on-backdrop="true"
+      >
         <ErrorCatchWidget :logFilepath="logPath" @ok-clicked="closeModalsById(['error-catch'])" />
       </b-modal>
       <b-modal

--- a/ui/js-utils/TextValidation.js
+++ b/ui/js-utils/TextValidation.js
@@ -214,8 +214,13 @@ export class TextValidation {
     if (parseInt(barcode.slice(7, 10)) < 0 || parseInt(barcode.slice(7, 10)) > 499) {
       return " ";
     }
-    // check if in beta one or two mode. if last digit invalid then mark the barcode as invalid
-    if (barcode[11] !== "2") {
+    if (barcode[1] === "L") {
+      // allow any magnet type for plate barcodes
+      if (["1", "3", "4"].includes(barcode[11])) {
+        return " ";
+      }
+    } else if (barcode[11] !== "2") {
+      // stim barcodes must end with 2
       return " ";
     }
     return "";


### PR DESCRIPTION
- ML barcodes may end in any digit other than 1, 3, or 4
- Error and warning modals are no longer hidden when clicking outside of them